### PR TITLE
Use collected goal-setting data in WOOP intake prompt

### DIFF
--- a/src/types/woop.ts
+++ b/src/types/woop.ts
@@ -1,0 +1,97 @@
+export interface WoopIntakeSummary {
+  user_profile: {
+    name: string | null;
+    persona: 'aspiring_entrepreneur' | 'existing_entrepreneur' | 'unemployed_youth' | 'experienced_worker' | 'general_jobseeker' | null;
+    region: string | null;
+    language: string | null;
+    stage: 'idea' | 'MVP' | 'early_revenue' | 'scaling' | null;
+    timezone: string | null;
+  };
+  summary: string;
+  goal_setting: {
+    primary_goal: string;
+    timeframe: '24h' | '4w' | '3m' | '12m' | 'none' | null;
+    previous_experience: string[];
+    current_skills: string[];
+    target_roles_or_markets: string[];
+    current_challenges: string[];
+    time_commitment_hours_per_week: number | null;
+    budget_usd_cap: number | null;
+    constraints: string[];
+  };
+  skillcraft_summary: {
+    top_skills: Array<{
+      name: string;
+      evidence: string;
+    }>;
+    personality: {
+      extraversion: 'low' | 'medium' | 'high' | null;
+      agreeableness: 'low' | 'medium' | 'high' | null;
+      conscientiousness: 'low' | 'medium' | 'high' | null;
+      emotional_regulation: 'low' | 'medium' | 'high' | null;
+      openness: 'low' | 'medium' | 'high' | null;
+      notes: string;
+    };
+    source_doc: string;
+  };
+  derived_insights: {
+    strengths: string[];
+    risks: string[];
+    capability_gaps: string[];
+    learning_topics: string[];
+    personality_implications: string[];
+  };
+  availability: {
+    weekly_windows: Array<{
+      day: 'Mon' | 'Tue' | 'Wed' | 'Thu' | 'Fri' | 'Sat' | 'Sun';
+      start_local: string;
+      end_local: string;
+    }>;
+    notes: string;
+  };
+  normalizations: {
+    skills_taxonomy: Array<{
+      raw: string;
+      normalized: string;
+    }>;
+    personality_mapping_notes: string;
+  };
+  assumptions: string[];
+  confidence: 'high' | 'medium' | 'low';
+  tokens_estimate: number;
+}
+
+export interface WoopWish {
+  wish_statement: string;
+  rationale: string;
+  clarifying_question: string | null;
+}
+
+export interface WoopOutcome {
+  positive_outcome: string;
+  success_metrics: string[];
+  rationale: string;
+  clarifying_question: string | null;
+}
+
+export interface WoopObstacles {
+  internal_obstacles: string[];
+  external_obstacles: string[];
+  capability_gaps: string[];
+  rationale: string;
+  clarifying_question: string | null;
+}
+
+export interface WoopPlan {
+  roadmap_steps: Array<{
+    step: string;
+    actions: string[];
+    measurement: string;
+    timeline: string;
+  }>;
+  business_plan: {
+    budget_considerations: string[];
+    ops_considerations: string[];
+    gtm_considerations: string[];
+  };
+}

--- a/src/utils/azureOpenAI.ts
+++ b/src/utils/azureOpenAI.ts
@@ -1,0 +1,100 @@
+export type AzureChatRole = 'system' | 'user' | 'assistant';
+
+export interface AzureChatMessage {
+  role: AzureChatRole;
+  content: string;
+}
+
+interface ChatCompletionOptions {
+  temperature?: number;
+  maxTokens?: number;
+}
+
+interface AzureChatCompletionResponse {
+  choices: Array<{
+    message: {
+      role: AzureChatRole;
+      content?: string;
+    };
+  }>;
+}
+
+const DEFAULT_API_VERSION = '2024-02-15-preview';
+
+const getAzureConfig = () => {
+  const endpoint = import.meta.env.VITE_AZURE_OPENAI_ENDPOINT;
+  const apiKey = import.meta.env.VITE_AZURE_OPENAI_KEY;
+  const deployment = import.meta.env.VITE_AZURE_OPENAI_DEPLOYMENT;
+  const apiVersion = import.meta.env.VITE_AZURE_OPENAI_API_VERSION || DEFAULT_API_VERSION;
+
+  if (!endpoint || !apiKey || !deployment) {
+    throw new Error('Azure OpenAI environment variables are not fully configured.');
+  }
+
+  return { endpoint, apiKey, deployment, apiVersion };
+};
+
+export const callAzureChatCompletion = async (
+  messages: AzureChatMessage[],
+  options: ChatCompletionOptions = {}
+): Promise<string> => {
+  const { endpoint, apiKey, deployment, apiVersion } = getAzureConfig();
+
+  const response = await fetch(
+    `${endpoint}/openai/deployments/${deployment}/chat/completions?api-version=${apiVersion}`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'api-key': apiKey
+      },
+      body: JSON.stringify({
+        messages,
+        temperature: options.temperature ?? 0.2,
+        max_tokens: options.maxTokens ?? 1200,
+        top_p: 0.95
+      })
+    }
+  );
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Azure OpenAI request failed: ${response.status} ${response.statusText} - ${errorText}`);
+  }
+
+  const data = (await response.json()) as AzureChatCompletionResponse;
+  const content = data.choices?.[0]?.message?.content;
+
+  if (!content) {
+    throw new Error('Azure OpenAI response did not include any content.');
+  }
+
+  return content.trim();
+};
+
+const stripCodeFences = (text: string) => {
+  if (text.startsWith('```')) {
+    const fenceMatch = text.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i);
+    if (fenceMatch) {
+      return fenceMatch[1];
+    }
+  }
+  return text;
+};
+
+export const extractJsonString = (text: string) => {
+  const trimmed = stripCodeFences(text.trim());
+  const firstBrace = trimmed.indexOf('{');
+  const lastBrace = trimmed.lastIndexOf('}');
+
+  if (firstBrace !== -1 && lastBrace !== -1 && lastBrace > firstBrace) {
+    return trimmed.slice(firstBrace, lastBrace + 1);
+  }
+
+  return trimmed;
+};
+
+export const parseAzureJSON = <T>(text: string): T => {
+  const jsonString = extractJsonString(text);
+  return JSON.parse(jsonString) as T;
+};


### PR DESCRIPTION
## Summary
- replace the static WOOP intake prompt with a helper that injects the signed-in entrepreneur's goal-setting inputs and contact details
- keep the existing multi-step WOOP workflow while sourcing SkillCraft text from any stored profile results or flagging gaps

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68daab509500832985ec8848f99e887c