### PR TITLE
Persist user inputs for WOOP generation

### DIFF
--- a/src/components/tracks/GroupA/EntrepreneurDashboard.tsx
+++ b/src/components/tracks/GroupA/EntrepreneurDashboard.tsx
@@ -92,6 +92,9 @@ const buildWoopIntakePrompt = (user: User | null) => {
     getRecordFromProfile('assessmentQuestionnaire') ||
     getRecordFromProfile('assessmentAnswers');
 
+  const goalSettingData = getRecordFromProfile('goalSettingData');
+  const wageQuestionnaire = getRecordFromProfile('wageEmploymentQuestionnaire');
+
   const goalSettingLinesSections: string[] = [
     'USER OVERVIEW',
     `Full name: ${formatPromptValue(user?.fullName)}`,
@@ -107,6 +110,8 @@ const buildWoopIntakePrompt = (user: User | null) => {
       profile.experienceYears !== undefined ? profile.experienceYears : null,
     )}`,
     `Preferred time commitment: ${formatPromptValue(profile.timeCommitment)}`,
+    `Career goals: ${formatPromptValue(extendedProfile?.careerGoals ?? goalSettingData?.careerGoals)}`,
+    `Skills to improve: ${formatPromptValue(extendedProfile?.skillsToImprove ?? goalSettingData?.skillsToImprove)}`,
     `Career level: ${formatPromptValue(extendedProfile?.careerLevel)}`,
     `Has work experience: ${formatPromptValue(extendedProfile?.hasWorkExperience)}`,
     '',
@@ -119,6 +124,25 @@ const buildWoopIntakePrompt = (user: User | null) => {
     });
   } else {
     goalSettingLinesSections.push('Assessment questionnaire responses: Not provided by the user.');
+  }
+
+  if (goalSettingData) {
+    goalSettingLinesSections.push(
+      '',
+      'EXTENDED GOAL SETTING (Opportunity Track)',
+      `Business idea or career vision: ${formatPromptValue(goalSettingData.businessIdea)}`,
+      `Time commitment: ${formatPromptValue(goalSettingData.timeCommitment)}`,
+      `Career goals: ${formatPromptValue(goalSettingData.careerGoals)}`,
+      `Skills to improve: ${formatPromptValue(goalSettingData.skillsToImprove)}`
+    );
+  }
+
+  if (wageQuestionnaire) {
+    goalSettingLinesSections.push(
+      '',
+      'WAGE EMPLOYMENT QUESTIONNAIRE',
+      `Work experience summary: ${formatPromptValue(wageQuestionnaire.workExperience)}`
+    );
   }
 
   goalSettingLinesSections.push(

--- a/src/components/tracks/GroupC/OpportunitySeekersDashboard.tsx
+++ b/src/components/tracks/GroupC/OpportunitySeekersDashboard.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useAuth } from '../../../contexts/AuthContext';
 import { useNavigate } from 'react-router-dom';
 import { DashboardLayout } from '../../dashboard/DashboardLayout';
@@ -32,6 +32,13 @@ import {
   ArrowLeft
 } from 'lucide-react';
 
+type GoalSettingForm = {
+  businessIdea: string;
+  timeCommitment: string;
+  careerGoals: string;
+  skillsToImprove: string;
+};
+
 const opportunitySeekersSteps: ProgressStep[] = [
   { id: 'skillcraft-wage-employment', label: 'Skillcraft Wage Employment Tasks', completed: false, current: true },
   { id: 'goal-setting', label: 'Goal Setting', completed: false, current: false },
@@ -46,12 +53,60 @@ export const OpportunitySeekersDashboard: React.FC = () => {
   const [currentStep, setCurrentStep] = useState('skillcraft-wage-employment');
   const [assessmentStarted, setAssessmentStarted] = useState(false);
   const [showResults, setShowResults] = useState(false);
-  const [goalSettingData, setGoalSettingData] = useState({
-    businessIdea: '',
-    timeCommitment: '',
-    careerGoals: '',
-    skillsToImprove: ''
-  });
+  const [goalSettingData, setGoalSettingData] = useState<GoalSettingForm>(() => ({
+    businessIdea: user?.profile?.goalSettingData?.businessIdea || user?.profile?.businessIdea || '',
+    timeCommitment: user?.profile?.goalSettingData?.timeCommitment || user?.profile?.timeCommitment || '',
+    careerGoals: user?.profile?.goalSettingData?.careerGoals || user?.profile?.careerGoals || '',
+    skillsToImprove: user?.profile?.goalSettingData?.skillsToImprove || user?.profile?.skillsToImprove || ''
+  }));
+
+  useEffect(() => {
+    const stored: GoalSettingForm = {
+      businessIdea: user?.profile?.goalSettingData?.businessIdea || user?.profile?.businessIdea || '',
+      timeCommitment: user?.profile?.goalSettingData?.timeCommitment || user?.profile?.timeCommitment || '',
+      careerGoals: user?.profile?.goalSettingData?.careerGoals || user?.profile?.careerGoals || '',
+      skillsToImprove: user?.profile?.goalSettingData?.skillsToImprove || user?.profile?.skillsToImprove || ''
+    };
+
+    setGoalSettingData(prev =>
+      prev.businessIdea === stored.businessIdea &&
+      prev.timeCommitment === stored.timeCommitment &&
+      prev.careerGoals === stored.careerGoals &&
+      prev.skillsToImprove === stored.skillsToImprove
+        ? prev
+        : stored
+    );
+  }, [
+    user?.profile?.goalSettingData?.businessIdea,
+    user?.profile?.goalSettingData?.timeCommitment,
+    user?.profile?.goalSettingData?.careerGoals,
+    user?.profile?.goalSettingData?.skillsToImprove,
+    user?.profile?.businessIdea,
+    user?.profile?.timeCommitment,
+    user?.profile?.careerGoals,
+    user?.profile?.skillsToImprove
+  ]);
+
+  const persistGoalSettingData = (updated: GoalSettingForm) => {
+    updateUser({
+      profile: {
+        ...user?.profile,
+        goalSettingData: updated,
+        businessIdea: updated.businessIdea,
+        timeCommitment: updated.timeCommitment,
+        careerGoals: updated.careerGoals,
+        skillsToImprove: updated.skillsToImprove
+      }
+    });
+  };
+
+  const handleGoalSettingChange = (field: keyof GoalSettingForm, value: string) => {
+    setGoalSettingData(prev => {
+      const updated = { ...prev, [field]: value } as GoalSettingForm;
+      persistGoalSettingData(updated);
+      return updated;
+    });
+  };
 
   const handleStepClick = (stepId: string) => {
     const completedSteps = user?.progress?.completedSteps || [];
@@ -94,12 +149,7 @@ export const OpportunitySeekersDashboard: React.FC = () => {
 
   const handleGoalSettingSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    updateUser({
-      profile: {
-        ...user?.profile,
-        goalSettingData
-      }
-    });
+    persistGoalSettingData(goalSettingData);
     completeStep('goal-setting', 'ai-training-plan');
   };
 
@@ -297,7 +347,7 @@ export const OpportunitySeekersDashboard: React.FC = () => {
                   </label>
                   <textarea
                     value={goalSettingData.businessIdea}
-                    onChange={(e) => setGoalSettingData(prev => ({ ...prev, businessIdea: e.target.value }))}
+                    onChange={e => handleGoalSettingChange('businessIdea', e.target.value)}
                     rows={3}
                     className="neuro-input resize-none text-lg"
                     placeholder="Describe your ideal career direction or business idea..."
@@ -311,7 +361,7 @@ export const OpportunitySeekersDashboard: React.FC = () => {
                   </label>
                   <select
                     value={goalSettingData.timeCommitment}
-                    onChange={(e) => setGoalSettingData(prev => ({ ...prev, timeCommitment: e.target.value }))}
+                    onChange={e => handleGoalSettingChange('timeCommitment', e.target.value)}
                     className="neuro-select text-lg"
                     required
                   >
@@ -329,7 +379,7 @@ export const OpportunitySeekersDashboard: React.FC = () => {
                   </label>
                   <textarea
                     value={goalSettingData.careerGoals}
-                    onChange={(e) => setGoalSettingData(prev => ({ ...prev, careerGoals: e.target.value }))}
+                    onChange={e => handleGoalSettingChange('careerGoals', e.target.value)}
                     rows={3}
                     className="neuro-input resize-none text-lg"
                     placeholder="What are your specific career transition goals?"
@@ -343,7 +393,7 @@ export const OpportunitySeekersDashboard: React.FC = () => {
                   </label>
                   <textarea
                     value={goalSettingData.skillsToImprove}
-                    onChange={(e) => setGoalSettingData(prev => ({ ...prev, skillsToImprove: e.target.value }))}
+                    onChange={e => handleGoalSettingChange('skillsToImprove', e.target.value)}
                     rows={3}
                     className="neuro-input resize-none text-lg"
                     placeholder="What skills would you like to develop or improve?"

--- a/src/components/tracks/GroupC/WageEmploymentDashboard.tsx
+++ b/src/components/tracks/GroupC/WageEmploymentDashboard.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useAuth } from '../../../contexts/AuthContext';
+import { useNavigate } from 'react-router-dom';
 import { DashboardLayout } from '../../dashboard/DashboardLayout';
 import { ProgressStep } from '../../../types';
 import { AssessmentResults } from '../../assessment/AssessmentResults';
@@ -32,9 +33,32 @@ const wageEmploymentSteps: ProgressStep[] = [
 
 export const WageEmploymentDashboard: React.FC = () => {
   const { user, updateUser } = useAuth();
+  const navigate = useNavigate();
   const [currentStep, setCurrentStep] = useState('skillcraft-riasec');
   const [assessmentStarted, setAssessmentStarted] = useState(false);
   const [showResults, setShowResults] = useState(false);
+  const [questionnaireResponse, setQuestionnaireResponse] = useState<string>(
+    () => (user?.profile?.wageEmploymentQuestionnaire?.workExperience as string) || ''
+  );
+
+  useEffect(() => {
+    const stored = (user?.profile?.wageEmploymentQuestionnaire?.workExperience as string) || '';
+    setQuestionnaireResponse(prev => (prev === stored ? prev : stored));
+  }, [user?.profile?.wageEmploymentQuestionnaire?.workExperience]);
+
+  const persistWageQuestionnaire = (workExperience: string) => {
+    updateUser({
+      profile: {
+        ...user?.profile,
+        wageEmploymentQuestionnaire: { workExperience }
+      }
+    });
+  };
+
+  const handleWageQuestionnaireChange = (value: string) => {
+    setQuestionnaireResponse(value);
+    persistWageQuestionnaire(value);
+  };
 
   const handleStepClick = (stepId: string) => {
     const completedSteps = user?.progress?.completedSteps || [];
@@ -220,6 +244,9 @@ export const WageEmploymentDashboard: React.FC = () => {
                     rows={3}
                     className="neuro-input resize-none text-lg"
                     placeholder="Describe your work experience and career background..."
+                    value={questionnaireResponse}
+                    onChange={e => handleWageQuestionnaireChange(e.target.value)}
+                    required
                   />
                 </div>
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -16,9 +16,34 @@ export interface User {
     businessCategory?: string;
     experienceYears?: number;
     timeCommitment?: string;
+    careerGoals?: string;
+    skillsToImprove?: string;
     skillcraftResults?: any;
     careerLevel?: 'entry' | 'mid' | 'advanced';
     hasWorkExperience?: boolean;
+    goalSettingData?: {
+      businessIdea?: string;
+      timeCommitment?: string;
+      careerGoals?: string;
+      skillsToImprove?: string;
+    };
+    assessmentResponses?: Record<string, string>;
+    assessmentRecommendation?: {
+      track: string;
+      confidence: number;
+    };
+    assessmentQuestionnaire?: Record<string, string>;
+    priorExperience?: {
+      workExperience?: string;
+      educationLevel?: string;
+      careerGoals?: string;
+      skillsConfidence?: string;
+      learningStyle?: string;
+      timeAvailable?: string;
+    };
+    wageEmploymentQuestionnaire?: {
+      workExperience?: string;
+    };
   };
 }
 


### PR DESCRIPTION
## Summary
- persist assessment questionnaire responses and recommendations on the user profile so progress is restored and WOOP can access the data
- sync wage employment, pathfinder, and opportunity seeker form inputs with the stored profile and update the WOOP prompt builder to include the saved details
- extend user profile typing to cover the new persisted fields used across dashboards

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dad83c3c04832984b59aa7886fb194