### PR TITLE
Add entrepreneur learning plan recommendations page

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -92,3 +92,5 @@ export interface AdminSettings {
     [key: string]: number;
   };
 }
+
+export * from './learningPlan';

--- a/src/types/learningPlan.ts
+++ b/src/types/learningPlan.ts
@@ -1,0 +1,42 @@
+export type LearningPlanDifficulty = 'beginner' | 'intermediate' | 'advanced' | null;
+
+export type VentureStage = 'idea' | 'MVP' | 'early_revenue' | 'scaling';
+
+export interface LearningPlanSequenceItem {
+  order: number;
+  course_title: string;
+  provider_name: string;
+  url: string;
+  difficulty: LearningPlanDifficulty;
+  estimated_hours: number;
+  planned_weekly_hours: number;
+  expected_duration_weeks: number;
+  why_chosen: string;
+}
+
+export interface LearningPlanCourseSummary {
+  course_title: string;
+  provider_name: string;
+  url: string;
+  difficulty: LearningPlanDifficulty;
+  estimated_hours: number;
+}
+
+export interface LearningPlanRecommendation {
+  skill: string;
+  user_info: {
+    stage: VentureStage;
+    region: string | null;
+    background: string | null;
+  };
+  time_commitment_hours_per_week: number;
+  learning_plan: {
+    plan_summary: string;
+    weekly_hours: number;
+    total_duration_weeks: number;
+    sequence: LearningPlanSequenceItem[];
+  };
+  all_relevant_courses: LearningPlanCourseSummary[];
+  assumptions: string[];
+  confidence: 'high' | 'medium' | 'low';
+}


### PR DESCRIPTION
## Summary
- define typed structures for learning plan recommendations returned by the external API
- add a new learning-course recommendation step after the WOOP report in the entrepreneur dashboard, including API integration and UI
- handle loading, error, and display states for the personalized learning plan data

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd80b968e08329a281f4b211848949