### PR TITLE
Integrate RAGFlow learning plan API

### DIFF
--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,10 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_RAGFLOW_BACKEND_URL?: string;
+  readonly VITE_RAGFLOW_BACKEND_API_KEY?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## Summary
- replace the placeholder learning plan fetch with a call to the RAGFlow chat completion API
- build the prompt dynamically from the user context and parse the JSON response into the dashboard state
- declare the new RAGFlow environment variables for TypeScript awareness

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd87f20e10832980096d4c462364a0