### PR TITLE
Add entrepreneurship foundations page for new founders

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { TrackSelection } from './components/tracks/TrackSelection';
 import { WageEmploymentSubSelection } from './components/tracks/WageEmploymentSubSelection';
 import { TrackRecommendation } from './components/tracks/TrackRecommendation';
 import { EntrepreneurDashboard } from './components/tracks/GroupA/EntrepreneurDashboard';
+import { EntrepreneurFoundations } from './components/tracks/GroupA/EntrepreneurFoundations';
 import { WageEmploymentDashboard } from './components/tracks/GroupC/WageEmploymentDashboard';
 import { PathfinderDashboard } from './components/tracks/GroupC/PathfinderDashboard';
 import { OpportunitySeekersDashboard } from './components/tracks/GroupC/OpportunitySeekersDashboard';
@@ -101,6 +102,12 @@ const AppRoutes: React.FC = () => {
       <Route path="/entrepreneur/dashboard" element={
         <PrivateRoute>
           <EntrepreneurDashboard />
+        </PrivateRoute>
+      } />
+
+      <Route path="/entrepreneur/foundations" element={
+        <PrivateRoute>
+          <EntrepreneurFoundations />
         </PrivateRoute>
       } />
       

--- a/src/components/tracks/GroupA/EntrepreneurDashboard.tsx
+++ b/src/components/tracks/GroupA/EntrepreneurDashboard.tsx
@@ -1,7 +1,8 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../../../contexts/AuthContext';
 import { DashboardLayout } from '../../dashboard/DashboardLayout';
-import { BusinessDevelopmentIntake, LearningPlanRecommendation, ProgressStep, User, VentureStage } from '../../../types';
+import { BusinessDevelopmentIntake, LearningPlanRecommendation, User, VentureStage } from '../../../types';
 import { WoopIntakeSummary, WoopWish, WoopOutcome, WoopObstacles, WoopPlan } from '../../../types/woop';
 import { AzureChatMessage, callAzureChatCompletion, parseAzureJSON } from '../../../utils/azureOpenAI';
 import { AssessmentResults } from '../../assessment/AssessmentResults';
@@ -36,16 +37,7 @@ import {
   RefreshCw,
   Compass
 } from 'lucide-react';
-
-const entrepreneurSteps: ProgressStep[] = [
-  { id: 'skillcraft-entrepreneurship-tasks', label: 'SkillCraft Entrepreneurship Tasks', completed: false, current: true },
-  { id: 'assessment-questionnaire', label: 'Assessment & Idea Scope', completed: false, current: false },
-  { id: 'business-plan-creation', label: 'Business Plan Creation', completed: false, current: false },
-  { id: 'learning-plan-recommendations', label: 'Learning Course Recommendations', completed: false, current: false },
-  { id: 'ai-mentor-program', label: 'AI Mentor Program', completed: false, current: false },
-  { id: 'networking-funding', label: 'Networking and Funding Resources', completed: false, current: false },
-  { id: 'skills-passport-certificate', label: 'Skills Passport Certificate', completed: false, current: false }
-];
+import { entrepreneurSteps } from './entrepreneurSteps';
 
 const formatPromptValue = (value: unknown): string => {
   if (value === undefined || value === null) {
@@ -592,8 +584,10 @@ OUTPUT FORMAT:
 
 export const EntrepreneurDashboard: React.FC = () => {
   const { user, updateUser } = useAuth();
+  const navigate = useNavigate();
   const [currentStep, setCurrentStep] = useState('skillcraft-entrepreneurship-tasks');
   const [assessmentStarted, setAssessmentStarted] = useState(false);
+  const [hasAcknowledgedBusinessPlan, setHasAcknowledgedBusinessPlan] = useState(false);
   const [chatMessages, setChatMessages] = useState([
     {
       id: '1',
@@ -980,6 +974,35 @@ export const EntrepreneurDashboard: React.FC = () => {
       case 'skillcraft-entrepreneurship-tasks':
         return (
           <div className="p-8 space-y-8 bg-neuro-bg">
+            {!hasAcknowledgedBusinessPlan && (
+              <div className="neuro-inset p-6 rounded-neuro-lg border border-neuro-primary/20">
+                <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-6">
+                  <div className="flex-1">
+                    <h3 className="text-2xl font-bold neuro-text-primary mb-2">
+                      Do you already have a business plan?
+                    </h3>
+                    <p className="neuro-text-secondary text-sm sm:text-base">
+                      If you&apos;re just getting started, we recommend reviewing a few foundational
+                      entrepreneurship courses before diving into SkillCraft tasks.
+                    </p>
+                  </div>
+                  <div className="flex flex-col sm:flex-row gap-3">
+                    <button
+                      onClick={() => setHasAcknowledgedBusinessPlan(true)}
+                      className="neuro-button flex-1 px-6 py-3 rounded-neuro"
+                    >
+                      Yes, let&apos;s continue
+                    </button>
+                    <button
+                      onClick={() => navigate('/entrepreneur/foundations')}
+                      className="neuro-button-primary flex-1 px-6 py-3 rounded-neuro"
+                    >
+                      No, show foundational learning
+                    </button>
+                  </div>
+                </div>
+              </div>
+            )}
             <div className="neuro-card hover:shadow-neuro-hover transition-all duration-300">
               <div className="text-center mb-8">
                 <div className="w-24 h-24 neuro-icon mx-auto mb-6 bg-gradient-to-br from-neuro-primary to-neuro-primary-light neuro-animate-float">

--- a/src/components/tracks/GroupA/EntrepreneurFoundations.tsx
+++ b/src/components/tracks/GroupA/EntrepreneurFoundations.tsx
@@ -1,0 +1,124 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { GraduationCap, BookOpen, ArrowRight, Compass, Lightbulb } from 'lucide-react';
+import { DashboardLayout } from '../../dashboard/DashboardLayout';
+import { useAuth } from '../../../contexts/AuthContext';
+import { entrepreneurSteps } from './entrepreneurSteps';
+
+const foundationalCourses = [
+  {
+    title: 'Entrepreneurship 101: Who Is Your Customer?',
+    provider: 'MITx (edX)',
+    duration: '6 weeks',
+    focus: 'Customer discovery, value proposition design, and market validation fundamentals.'
+  },
+  {
+    title: 'Business Foundations Specialization',
+    provider: 'Wharton Online (Coursera)',
+    duration: '4 courses · self-paced',
+    focus: 'Accounting, operations, marketing, and management essentials for new founders.'
+  },
+  {
+    title: 'Financial Accounting Fundamentals',
+    provider: 'University of Virginia (Coursera)',
+    duration: '4 weeks',
+    focus: 'Reading financial statements, understanding cash flow, and managing startup finances.'
+  },
+  {
+    title: 'Marketing Fundamentals for Entrepreneurs',
+    provider: 'Google Digital Garage',
+    duration: '10 modules',
+    focus: 'Brand positioning, customer acquisition channels, and go-to-market basics.'
+  },
+  {
+    title: 'Small Business Legal Basics',
+    provider: 'U.S. SBA Learning Center',
+    duration: 'Self-paced',
+    focus: 'Business structures, permits, and compliance considerations for new ventures.'
+  }
+];
+
+export const EntrepreneurFoundations: React.FC = () => {
+  const navigate = useNavigate();
+  const { user } = useAuth();
+
+  const steps = entrepreneurSteps.map(step => ({
+    ...step,
+    current: step.id === 'skillcraft-entrepreneurship-tasks',
+    completed: user?.progress?.completedSteps?.includes(step.id) || false
+  }));
+
+  return (
+    <DashboardLayout
+      title="Entrepreneurship Track - Foundational Learning"
+      steps={steps}
+      onStepClick={(_stepId) => navigate('/entrepreneur/dashboard')}
+    >
+      <div className="bg-neuro-bg">
+        <div className="p-8 space-y-8">
+          <div className="neuro-card p-8 text-center space-y-4">
+            <div className="w-20 h-20 neuro-icon mx-auto bg-gradient-to-br from-neuro-secondary to-pink-400">
+              <GraduationCap className="w-10 h-10 text-white" />
+            </div>
+            <h2 className="text-3xl font-bold neuro-text-primary">Build Your Business Foundations</h2>
+            <p className="text-lg neuro-text-secondary max-w-2xl mx-auto">
+              These curated courses will help you strengthen the fundamentals needed before crafting a full business plan. Once you feel confident with the basics, you can jump back into the SkillCraft Entrepreneurship Tasks to continue your journey.
+            </p>
+          </div>
+
+          <div className="grid gap-6 md:grid-cols-2">
+            {foundationalCourses.map(course => (
+              <div key={course.title} className="neuro-surface p-6 rounded-neuro-lg space-y-4 hover:shadow-neuro-hover transition-all duration-300">
+                <div className="flex items-center gap-4">
+                  <div className="w-12 h-12 neuro-icon bg-gradient-to-br from-neuro-primary to-neuro-primary-light">
+                    <BookOpen className="w-6 h-6 text-white" />
+                  </div>
+                  <div>
+                    <h3 className="text-xl font-semibold neuro-text-primary">{course.title}</h3>
+                    <p className="text-sm text-neuro-secondary">{course.provider}</p>
+                  </div>
+                </div>
+                <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 text-sm text-neuro-secondary">
+                  <span className="font-medium text-neuro-primary">Duration:</span>
+                  <span>{course.duration}</span>
+                </div>
+                <p className="text-sm neuro-text-secondary leading-relaxed">{course.focus}</p>
+              </div>
+            ))}
+          </div>
+
+          <div className="neuro-inset p-6 rounded-neuro-lg space-y-4">
+            <div className="flex items-start gap-4">
+              <div className="w-10 h-10 neuro-icon bg-gradient-to-br from-neuro-success to-green-400">
+                <Lightbulb className="w-6 h-6 text-white" />
+              </div>
+              <div>
+                <h3 className="text-xl font-semibold neuro-text-primary mb-1">Ready for Your Next Move?</h3>
+                <p className="text-sm neuro-text-secondary">
+                  Choose how you&apos;d like to continue. You can explore other career pathways or return to the entrepreneurship track when you feel prepared.
+                </p>
+              </div>
+            </div>
+            <div className="flex flex-col sm:flex-row gap-4 sm:justify-end">
+              <button
+                onClick={() => navigate('/career-exploration')}
+                className="neuro-button flex items-center justify-center gap-2 px-6 py-3 rounded-neuro"
+              >
+                <Compass className="w-5 h-5" />
+                <span>Visit Career Explorer</span>
+              </button>
+              <button
+                onClick={() => navigate('/entrepreneur/dashboard')}
+                className="neuro-button-primary flex items-center justify-center gap-2 px-6 py-3 rounded-neuro"
+              >
+                <ArrowRight className="w-5 h-5" />
+                <span>Continue to SkillCraft Entrepreneurship Tasks</span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </DashboardLayout>
+  );
+};
+

--- a/src/components/tracks/GroupA/entrepreneurSteps.ts
+++ b/src/components/tracks/GroupA/entrepreneurSteps.ts
@@ -1,0 +1,11 @@
+import { ProgressStep } from '../../../types';
+
+export const entrepreneurSteps: ProgressStep[] = [
+  { id: 'skillcraft-entrepreneurship-tasks', label: 'SkillCraft Entrepreneurship Tasks', completed: false, current: true },
+  { id: 'assessment-questionnaire', label: 'Assessment & Idea Scope', completed: false, current: false },
+  { id: 'business-plan-creation', label: 'Business Plan Creation', completed: false, current: false },
+  { id: 'learning-plan-recommendations', label: 'Learning Course Recommendations', completed: false, current: false },
+  { id: 'ai-mentor-program', label: 'AI Mentor Program', completed: false, current: false },
+  { id: 'networking-funding', label: 'Networking and Funding Resources', completed: false, current: false },
+  { id: 'skills-passport-certificate', label: 'Skills Passport Certificate', completed: false, current: false }
+];


### PR DESCRIPTION
## Summary
- add an entrepreneurship foundations page with curated learning resources and track navigation choices
- prompt SkillCraft users who lack a business plan to review foundational guidance before continuing the track
- centralize entrepreneur step metadata and register the new page in the routing table

## Testing
- npm run lint *(fails due to numerous pre-existing lint issues across the codebase)*

------
https://chatgpt.com/codex/tasks/task_e_68e6bcde160c8329bc5c731bfb085168