### PR TITLE
Redirect career explorer button to Pathfinder dashboard

### DIFF
--- a/src/components/tracks/GroupA/EntrepreneurFoundations.tsx
+++ b/src/components/tracks/GroupA/EntrepreneurFoundations.tsx
@@ -190,7 +190,7 @@ export const EntrepreneurFoundations: React.FC = () => {
             </div>
             <div className="flex flex-col sm:flex-row gap-4 sm:justify-end">
               <button
-                onClick={() => navigate('/career-exploration')}
+                onClick={() => navigate('/pathfinder/dashboard')}
                 className="neuro-button flex items-center justify-center gap-2 px-6 py-3 rounded-neuro"
               >
                 <Compass className="w-5 h-5" />


### PR DESCRIPTION
## Summary
- update the Visit Career Explorer button on the entrepreneur foundations page to navigate to the Pathfinder dashboard

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e6c11a95488329b0d4df1882f18071