### PR TITLE
Ensure Azure responses use JSON format

### DIFF
--- a/src/components/tracks/GroupA/EntrepreneurDashboard.tsx
+++ b/src/components/tracks/GroupA/EntrepreneurDashboard.tsx
@@ -1277,7 +1277,8 @@ export const EntrepreneurDashboard: React.FC = () => {
       const runStep = async <T,>(prompt: string, label: string, maxTokens?: number) => {
         const messages: AzureChatMessage[] = [...conversationHistory, { role: 'user', content: prompt }];
         const responseText = await callAzureChatCompletion(messages, {
-          maxTokens: maxTokens ?? 900
+          maxTokens: maxTokens ?? 900,
+          responseFormat: { type: 'json_object' }
         });
 
         conversationHistory.push({ role: 'user', content: prompt });

--- a/src/utils/azureOpenAI.ts
+++ b/src/utils/azureOpenAI.ts
@@ -5,9 +5,14 @@ export interface AzureChatMessage {
   content: string;
 }
 
+type JsonResponseFormat =
+  | { type: 'json_object' }
+  | { type: 'json_schema'; json_schema: Record<string, unknown> };
+
 interface ChatCompletionOptions {
   temperature?: number;
   maxTokens?: number;
+  responseFormat?: JsonResponseFormat;
 }
 
 interface AzureChatCompletionResponse {
@@ -52,7 +57,8 @@ export const callAzureChatCompletion = async (
         messages,
         temperature: options.temperature ?? 0.2,
         max_tokens: options.maxTokens ?? 1200,
-        top_p: 0.95
+        top_p: 0.95,
+        ...(options.responseFormat ? { response_format: options.responseFormat } : {})
       })
     }
   );


### PR DESCRIPTION
## Summary
- allow Azure chat completion requests to specify an explicit JSON response format
- request JSON-only output for WOOP generation steps to avoid plan parsing failures

## Testing
- npm run lint *(fails: existing lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e6d644364c83299a557ecb9f4bdff1