### PR TITLE
Add collapsible controls to Assessment & Idea Scope form

### DIFF
--- a/src/components/tracks/GroupA/EntrepreneurDashboard.tsx
+++ b/src/components/tracks/GroupA/EntrepreneurDashboard.tsx
@@ -35,7 +35,8 @@ import {
   BookOpen,
   Clock,
   RefreshCw,
-  Compass
+  Compass,
+  ChevronDown
 } from 'lucide-react';
 import { entrepreneurSteps } from './entrepreneurSteps';
 
@@ -192,6 +193,16 @@ type BusinessDevelopmentIntakeFormState = {
   immediateNeeds: string;
   successDefinition: string;
 };
+
+const ASSESSMENT_SECTION_IDS = {
+  yourIdea: 'assessment-section-your-idea',
+  targetAudience: 'assessment-section-target-audience',
+  differentiation: 'assessment-section-differentiation',
+  operations: 'assessment-section-operations',
+  nextSteps: 'assessment-section-next-steps'
+} as const;
+
+type AssessmentSectionKey = keyof typeof ASSESSMENT_SECTION_IDS;
 
 const createInitialBusinessIntakeForm = (
   intake?: BusinessDevelopmentIntake | null
@@ -615,6 +626,13 @@ export const EntrepreneurDashboard: React.FC = () => {
   const [businessIntakeForm, setBusinessIntakeForm] = useState<BusinessDevelopmentIntakeFormState>(() =>
     createInitialBusinessIntakeForm(user?.profile?.businessDevelopmentIntake ?? null)
   );
+  const [expandedAssessmentSections, setExpandedAssessmentSections] = useState<Record<AssessmentSectionKey, boolean>>({
+    yourIdea: true,
+    targetAudience: true,
+    differentiation: true,
+    operations: true,
+    nextSteps: true
+  });
 
   useEffect(() => {
     setBusinessIntakeForm(createInitialBusinessIntakeForm(user?.profile?.businessDevelopmentIntake ?? null));
@@ -629,6 +647,13 @@ export const EntrepreneurDashboard: React.FC = () => {
       [field]: value
     }));
   };
+
+  const toggleAssessmentSection = useCallback((section: AssessmentSectionKey) => {
+    setExpandedAssessmentSections(prev => ({
+      ...prev,
+      [section]: !prev[section]
+    }));
+  }, []);
 
   const ventureStage = normalizeVentureStage(woopSummary?.user_profile.stage);
 
@@ -1115,210 +1140,320 @@ export const EntrepreneurDashboard: React.FC = () => {
 
               <form onSubmit={handleBusinessIntakeSubmit} className="space-y-8">
                 <section className="space-y-6">
-                  <div>
-                    <h3 className="text-xl font-semibold neuro-text-primary">1. Your Idea</h3>
-                    <p className="text-sm neuro-text-secondary mt-2">
-                      Summarize the opportunity and why it matters right now.
-                    </p>
+                  <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
+                    <div>
+                      <h3 className="text-xl font-semibold neuro-text-primary">1. Your Idea</h3>
+                      <p className="text-sm neuro-text-secondary mt-2">
+                        Summarize the opportunity and why it matters right now.
+                      </p>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => toggleAssessmentSection('yourIdea')}
+                      className="inline-flex items-center gap-2 self-start rounded-neuro-lg border border-neuro-primary/20 px-4 py-2 text-sm font-semibold text-neuro-primary transition-colors hover:bg-neuro-primary/10 focus:outline-none focus:ring-2 focus:ring-neuro-primary/50"
+                      aria-expanded={expandedAssessmentSections.yourIdea}
+                      aria-controls={ASSESSMENT_SECTION_IDS.yourIdea}
+                    >
+                      <span>{expandedAssessmentSections.yourIdea ? 'Collapse' : 'Expand'}</span>
+                      <ChevronDown
+                        className={`w-4 h-4 transition-transform ${
+                          expandedAssessmentSections.yourIdea ? 'rotate-180' : ''
+                        }`}
+                      />
+                    </button>
                   </div>
 
-                  <div className="neuro-surface p-6 rounded-neuro-lg space-y-3">
-                    <label className="block text-sm font-semibold neuro-text-primary">Idea Name</label>
-                    <input
-                      className="neuro-input"
-                      placeholder="What do you call your idea?"
-                      value={businessIntakeForm.ideaName}
-                      onChange={event => handleBusinessIntakeChange('ideaName', event.target.value)}
-                      required
-                    />
-                  </div>
+                  <div
+                    id={ASSESSMENT_SECTION_IDS.yourIdea}
+                    className={`space-y-6 ${expandedAssessmentSections.yourIdea ? '' : 'hidden'}`}
+                    aria-hidden={!expandedAssessmentSections.yourIdea}
+                  >
+                    <div className="neuro-surface p-6 rounded-neuro-lg space-y-3">
+                      <label className="block text-sm font-semibold neuro-text-primary">Idea Name</label>
+                      <input
+                        className="neuro-input"
+                        placeholder="What do you call your idea?"
+                        value={businessIntakeForm.ideaName}
+                        onChange={event => handleBusinessIntakeChange('ideaName', event.target.value)}
+                        required
+                      />
+                    </div>
 
-                  <div className="neuro-surface p-6 rounded-neuro-lg space-y-3">
-                    <label className="block text-sm font-semibold neuro-text-primary">One sentence summary</label>
-                    <textarea
-                      className="neuro-input resize-none"
-                      rows={3}
-                      placeholder="Describe your idea in a single, powerful sentence."
-                      value={businessIntakeForm.ideaSummary}
-                      onChange={event => handleBusinessIntakeChange('ideaSummary', event.target.value)}
-                      required
-                    />
-                  </div>
+                    <div className="neuro-surface p-6 rounded-neuro-lg space-y-3">
+                      <label className="block text-sm font-semibold neuro-text-primary">One sentence summary</label>
+                      <textarea
+                        className="neuro-input resize-none"
+                        rows={3}
+                        placeholder="Describe your idea in a single, powerful sentence."
+                        value={businessIntakeForm.ideaSummary}
+                        onChange={event => handleBusinessIntakeChange('ideaSummary', event.target.value)}
+                        required
+                      />
+                    </div>
 
-                  <div className="neuro-surface p-6 rounded-neuro-lg space-y-3">
-                    <label className="block text-sm font-semibold neuro-text-primary">The problem</label>
-                    <textarea
-                      className="neuro-input resize-none"
-                      rows={3}
-                      placeholder="What pain or challenge are you solving?"
-                      value={businessIntakeForm.ideaProblem}
-                      onChange={event => handleBusinessIntakeChange('ideaProblem', event.target.value)}
-                      required
-                    />
-                  </div>
+                    <div className="neuro-surface p-6 rounded-neuro-lg space-y-3">
+                      <label className="block text-sm font-semibold neuro-text-primary">The problem</label>
+                      <textarea
+                        className="neuro-input resize-none"
+                        rows={3}
+                        placeholder="What pain or challenge are you solving?"
+                        value={businessIntakeForm.ideaProblem}
+                        onChange={event => handleBusinessIntakeChange('ideaProblem', event.target.value)}
+                        required
+                      />
+                    </div>
 
-                  <div className="neuro-surface p-6 rounded-neuro-lg space-y-3">
-                    <label className="block text-sm font-semibold neuro-text-primary">Why it matters</label>
-                    <textarea
-                      className="neuro-input resize-none"
-                      rows={3}
-                      placeholder="Why is solving this problem urgent or valuable now?"
-                      value={businessIntakeForm.ideaImportance}
-                      onChange={event => handleBusinessIntakeChange('ideaImportance', event.target.value)}
-                      required
-                    />
-                  </div>
-                </section>
-
-                <section className="space-y-6">
-                  <div>
-                    <h3 className="text-xl font-semibold neuro-text-primary">2. Who It’s For</h3>
-                    <p className="text-sm neuro-text-secondary mt-2">
-                      Clarify the audience you’re serving and their biggest struggle.
-                    </p>
-                  </div>
-
-                  <div className="neuro-surface p-6 rounded-neuro-lg space-y-3">
-                    <label className="block text-sm font-semibold neuro-text-primary">Main customer or user</label>
-                    <input
-                      className="neuro-input"
-                      placeholder="Who benefits the most from your idea?"
-                      value={businessIntakeForm.mainCustomer}
-                      onChange={event => handleBusinessIntakeChange('mainCustomer', event.target.value)}
-                      required
-                    />
-                  </div>
-
-                  <div className="neuro-surface p-6 rounded-neuro-lg space-y-3">
-                    <label className="block text-sm font-semibold neuro-text-primary">Their biggest pain point</label>
-                    <textarea
-                      className="neuro-input resize-none"
-                      rows={3}
-                      placeholder="What challenge do they face today?"
-                      value={businessIntakeForm.customerPainPoint}
-                      onChange={event => handleBusinessIntakeChange('customerPainPoint', event.target.value)}
-                      required
-                    />
-                  </div>
-
-                  <div className="neuro-surface p-6 rounded-neuro-lg space-y-3">
-                    <label className="block text-sm font-semibold neuro-text-primary">How your idea helps</label>
-                    <textarea
-                      className="neuro-input resize-none"
-                      rows={3}
-                      placeholder="Explain in simple terms how life gets better or easier."
-                      value={businessIntakeForm.ideaBenefit}
-                      onChange={event => handleBusinessIntakeChange('ideaBenefit', event.target.value)}
-                      required
-                    />
+                    <div className="neuro-surface p-6 rounded-neuro-lg space-y-3">
+                      <label className="block text-sm font-semibold neuro-text-primary">Why it matters</label>
+                      <textarea
+                        className="neuro-input resize-none"
+                        rows={3}
+                        placeholder="Why is solving this problem urgent or valuable now?"
+                        value={businessIntakeForm.ideaImportance}
+                        onChange={event => handleBusinessIntakeChange('ideaImportance', event.target.value)}
+                        required
+                      />
+                    </div>
                   </div>
                 </section>
 
                 <section className="space-y-6">
-                  <div>
-                    <h3 className="text-xl font-semibold neuro-text-primary">3. What Makes It Different</h3>
-                    <p className="text-sm neuro-text-secondary mt-2">
-                      Show how you stand apart from what exists today.
-                    </p>
+                  <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
+                    <div>
+                      <h3 className="text-xl font-semibold neuro-text-primary">2. Who It’s For</h3>
+                      <p className="text-sm neuro-text-secondary mt-2">
+                        Clarify the audience you’re serving and their biggest struggle.
+                      </p>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => toggleAssessmentSection('targetAudience')}
+                      className="inline-flex items-center gap-2 self-start rounded-neuro-lg border border-neuro-primary/20 px-4 py-2 text-sm font-semibold text-neuro-primary transition-colors hover:bg-neuro-primary/10 focus:outline-none focus:ring-2 focus:ring-neuro-primary/50"
+                      aria-expanded={expandedAssessmentSections.targetAudience}
+                      aria-controls={ASSESSMENT_SECTION_IDS.targetAudience}
+                    >
+                      <span>{expandedAssessmentSections.targetAudience ? 'Collapse' : 'Expand'}</span>
+                      <ChevronDown
+                        className={`w-4 h-4 transition-transform ${
+                          expandedAssessmentSections.targetAudience ? 'rotate-180' : ''
+                        }`}
+                      />
+                    </button>
                   </div>
 
-                  <div className="neuro-surface p-6 rounded-neuro-lg space-y-3">
-                    <label className="block text-sm font-semibold neuro-text-primary">Existing options</label>
-                    <textarea
-                      className="neuro-input resize-none"
-                      rows={3}
-                      placeholder="How do people solve this problem right now?"
-                      value={businessIntakeForm.existingOptions}
-                      onChange={event => handleBusinessIntakeChange('existingOptions', event.target.value)}
-                      required
-                    />
-                  </div>
+                  <div
+                    id={ASSESSMENT_SECTION_IDS.targetAudience}
+                    className={`space-y-6 ${expandedAssessmentSections.targetAudience ? '' : 'hidden'}`}
+                    aria-hidden={!expandedAssessmentSections.targetAudience}
+                  >
+                    <div className="neuro-surface p-6 rounded-neuro-lg space-y-3">
+                      <label className="block text-sm font-semibold neuro-text-primary">Main customer or user</label>
+                      <input
+                        className="neuro-input"
+                        placeholder="Who benefits the most from your idea?"
+                        value={businessIntakeForm.mainCustomer}
+                        onChange={event => handleBusinessIntakeChange('mainCustomer', event.target.value)}
+                        required
+                      />
+                    </div>
 
-                  <div className="neuro-surface p-6 rounded-neuro-lg space-y-3">
-                    <label className="block text-sm font-semibold neuro-text-primary">Your edge</label>
-                    <textarea
-                      className="neuro-input resize-none"
-                      rows={3}
-                      placeholder="What makes your approach better, faster, or more appealing?"
-                      value={businessIntakeForm.differentiator}
-                      onChange={event => handleBusinessIntakeChange('differentiator', event.target.value)}
-                      required
-                    />
-                  </div>
-                </section>
+                    <div className="neuro-surface p-6 rounded-neuro-lg space-y-3">
+                      <label className="block text-sm font-semibold neuro-text-primary">Their biggest pain point</label>
+                      <textarea
+                        className="neuro-input resize-none"
+                        rows={3}
+                        placeholder="What challenge do they face today?"
+                        value={businessIntakeForm.customerPainPoint}
+                        onChange={event => handleBusinessIntakeChange('customerPainPoint', event.target.value)}
+                        required
+                      />
+                    </div>
 
-                <section className="space-y-6">
-                  <div>
-                    <h3 className="text-xl font-semibold neuro-text-primary">4. How It Works</h3>
-                    <p className="text-sm neuro-text-secondary mt-2">
-                      Outline your offer, revenue model, and collaborators.
-                    </p>
-                  </div>
-
-                  <div className="neuro-surface p-6 rounded-neuro-lg space-y-3">
-                    <label className="block text-sm font-semibold neuro-text-primary">What you will offer</label>
-                    <input
-                      className="neuro-input"
-                      placeholder="Product, service, app, platform, or something else?"
-                      value={businessIntakeForm.offeringType}
-                      onChange={event => handleBusinessIntakeChange('offeringType', event.target.value)}
-                      required
-                    />
-                  </div>
-
-                  <div className="neuro-surface p-6 rounded-neuro-lg space-y-3">
-                    <label className="block text-sm font-semibold neuro-text-primary">How you'll earn money</label>
-                    <input
-                      className="neuro-input"
-                      placeholder="Sell, subscribe, partner, or another revenue path?"
-                      value={businessIntakeForm.revenueApproach}
-                      onChange={event => handleBusinessIntakeChange('revenueApproach', event.target.value)}
-                      required
-                    />
-                  </div>
-
-                  <div className="neuro-surface p-6 rounded-neuro-lg space-y-3">
-                    <label className="block text-sm font-semibold neuro-text-primary">Who you might work with</label>
-                    <textarea
-                      className="neuro-input resize-none"
-                      rows={3}
-                      placeholder="Key partners, suppliers, or helpers."
-                      value={businessIntakeForm.potentialPartners}
-                      onChange={event => handleBusinessIntakeChange('potentialPartners', event.target.value)}
-                    />
+                    <div className="neuro-surface p-6 rounded-neuro-lg space-y-3">
+                      <label className="block text-sm font-semibold neuro-text-primary">How your idea helps</label>
+                      <textarea
+                        className="neuro-input resize-none"
+                        rows={3}
+                        placeholder="Explain in simple terms how life gets better or easier."
+                        value={businessIntakeForm.ideaBenefit}
+                        onChange={event => handleBusinessIntakeChange('ideaBenefit', event.target.value)}
+                        required
+                      />
+                    </div>
                   </div>
                 </section>
 
                 <section className="space-y-6">
-                  <div>
-                    <h3 className="text-xl font-semibold neuro-text-primary">5. Next Steps</h3>
-                    <p className="text-sm neuro-text-secondary mt-2">
-                      Clarify what support you need and what success means to you.
-                    </p>
+                  <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
+                    <div>
+                      <h3 className="text-xl font-semibold neuro-text-primary">3. What Makes It Different</h3>
+                      <p className="text-sm neuro-text-secondary mt-2">
+                        Show how you stand apart from what exists today.
+                      </p>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => toggleAssessmentSection('differentiation')}
+                      className="inline-flex items-center gap-2 self-start rounded-neuro-lg border border-neuro-primary/20 px-4 py-2 text-sm font-semibold text-neuro-primary transition-colors hover:bg-neuro-primary/10 focus:outline-none focus:ring-2 focus:ring-neuro-primary/50"
+                      aria-expanded={expandedAssessmentSections.differentiation}
+                      aria-controls={ASSESSMENT_SECTION_IDS.differentiation}
+                    >
+                      <span>{expandedAssessmentSections.differentiation ? 'Collapse' : 'Expand'}</span>
+                      <ChevronDown
+                        className={`w-4 h-4 transition-transform ${
+                          expandedAssessmentSections.differentiation ? 'rotate-180' : ''
+                        }`}
+                      />
+                    </button>
                   </div>
 
-                  <div className="neuro-surface p-6 rounded-neuro-lg space-y-3">
-                    <label className="block text-sm font-semibold neuro-text-primary">What do you need right now?</label>
-                    <textarea
-                      className="neuro-input resize-none"
-                      rows={3}
-                      placeholder="Money, skills, team, feedback, or something else?"
-                      value={businessIntakeForm.immediateNeeds}
-                      onChange={event => handleBusinessIntakeChange('immediateNeeds', event.target.value)}
-                      required
-                    />
+                  <div
+                    id={ASSESSMENT_SECTION_IDS.differentiation}
+                    className={`space-y-6 ${expandedAssessmentSections.differentiation ? '' : 'hidden'}`}
+                    aria-hidden={!expandedAssessmentSections.differentiation}
+                  >
+                    <div className="neuro-surface p-6 rounded-neuro-lg space-y-3">
+                      <label className="block text-sm font-semibold neuro-text-primary">Existing options</label>
+                      <textarea
+                        className="neuro-input resize-none"
+                        rows={3}
+                        placeholder="How do people solve this problem right now?"
+                        value={businessIntakeForm.existingOptions}
+                        onChange={event => handleBusinessIntakeChange('existingOptions', event.target.value)}
+                        required
+                      />
+                    </div>
+
+                    <div className="neuro-surface p-6 rounded-neuro-lg space-y-3">
+                      <label className="block text-sm font-semibold neuro-text-primary">Your edge</label>
+                      <textarea
+                        className="neuro-input resize-none"
+                        rows={3}
+                        placeholder="What makes your approach better, faster, or more appealing?"
+                        value={businessIntakeForm.differentiator}
+                        onChange={event => handleBusinessIntakeChange('differentiator', event.target.value)}
+                        required
+                      />
+                    </div>
+                  </div>
+                </section>
+
+                <section className="space-y-6">
+                  <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
+                    <div>
+                      <h3 className="text-xl font-semibold neuro-text-primary">4. How It Works</h3>
+                      <p className="text-sm neuro-text-secondary mt-2">
+                        Outline your offer, revenue model, and collaborators.
+                      </p>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => toggleAssessmentSection('operations')}
+                      className="inline-flex items-center gap-2 self-start rounded-neuro-lg border border-neuro-primary/20 px-4 py-2 text-sm font-semibold text-neuro-primary transition-colors hover:bg-neuro-primary/10 focus:outline-none focus:ring-2 focus:ring-neuro-primary/50"
+                      aria-expanded={expandedAssessmentSections.operations}
+                      aria-controls={ASSESSMENT_SECTION_IDS.operations}
+                    >
+                      <span>{expandedAssessmentSections.operations ? 'Collapse' : 'Expand'}</span>
+                      <ChevronDown
+                        className={`w-4 h-4 transition-transform ${
+                          expandedAssessmentSections.operations ? 'rotate-180' : ''
+                        }`}
+                      />
+                    </button>
                   </div>
 
-                  <div className="neuro-surface p-6 rounded-neuro-lg space-y-3">
-                    <label className="block text-sm font-semibold neuro-text-primary">What success looks like</label>
-                    <textarea
-                      className="neuro-input resize-none"
-                      rows={3}
-                      placeholder="How will you know the idea is working?"
-                      value={businessIntakeForm.successDefinition}
-                      onChange={event => handleBusinessIntakeChange('successDefinition', event.target.value)}
-                      required
-                    />
+                  <div
+                    id={ASSESSMENT_SECTION_IDS.operations}
+                    className={`space-y-6 ${expandedAssessmentSections.operations ? '' : 'hidden'}`}
+                    aria-hidden={!expandedAssessmentSections.operations}
+                  >
+                    <div className="neuro-surface p-6 rounded-neuro-lg space-y-3">
+                      <label className="block text-sm font-semibold neuro-text-primary">What you will offer</label>
+                      <input
+                        className="neuro-input"
+                        placeholder="Product, service, app, platform, or something else?"
+                        value={businessIntakeForm.offeringType}
+                        onChange={event => handleBusinessIntakeChange('offeringType', event.target.value)}
+                        required
+                      />
+                    </div>
+
+                    <div className="neuro-surface p-6 rounded-neuro-lg space-y-3">
+                      <label className="block text-sm font-semibold neuro-text-primary">How you'll earn money</label>
+                      <input
+                        className="neuro-input"
+                        placeholder="Sell, subscribe, partner, or another revenue path?"
+                        value={businessIntakeForm.revenueApproach}
+                        onChange={event => handleBusinessIntakeChange('revenueApproach', event.target.value)}
+                        required
+                      />
+                    </div>
+
+                    <div className="neuro-surface p-6 rounded-neuro-lg space-y-3">
+                      <label className="block text-sm font-semibold neuro-text-primary">Who you might work with</label>
+                      <textarea
+                        className="neuro-input resize-none"
+                        rows={3}
+                        placeholder="Key partners, suppliers, or helpers."
+                        value={businessIntakeForm.potentialPartners}
+                        onChange={event => handleBusinessIntakeChange('potentialPartners', event.target.value)}
+                      />
+                    </div>
+                  </div>
+                </section>
+
+                <section className="space-y-6">
+                  <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
+                    <div>
+                      <h3 className="text-xl font-semibold neuro-text-primary">5. Next Steps</h3>
+                      <p className="text-sm neuro-text-secondary mt-2">
+                        Clarify what support you need and what success means to you.
+                      </p>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => toggleAssessmentSection('nextSteps')}
+                      className="inline-flex items-center gap-2 self-start rounded-neuro-lg border border-neuro-primary/20 px-4 py-2 text-sm font-semibold text-neuro-primary transition-colors hover:bg-neuro-primary/10 focus:outline-none focus:ring-2 focus:ring-neuro-primary/50"
+                      aria-expanded={expandedAssessmentSections.nextSteps}
+                      aria-controls={ASSESSMENT_SECTION_IDS.nextSteps}
+                    >
+                      <span>{expandedAssessmentSections.nextSteps ? 'Collapse' : 'Expand'}</span>
+                      <ChevronDown
+                        className={`w-4 h-4 transition-transform ${
+                          expandedAssessmentSections.nextSteps ? 'rotate-180' : ''
+                        }`}
+                      />
+                    </button>
+                  </div>
+
+                  <div
+                    id={ASSESSMENT_SECTION_IDS.nextSteps}
+                    className={`space-y-6 ${expandedAssessmentSections.nextSteps ? '' : 'hidden'}`}
+                    aria-hidden={!expandedAssessmentSections.nextSteps}
+                  >
+                    <div className="neuro-surface p-6 rounded-neuro-lg space-y-3">
+                      <label className="block text-sm font-semibold neuro-text-primary">What do you need right now?</label>
+                      <textarea
+                        className="neuro-input resize-none"
+                        rows={3}
+                        placeholder="Money, skills, team, feedback, or something else?"
+                        value={businessIntakeForm.immediateNeeds}
+                        onChange={event => handleBusinessIntakeChange('immediateNeeds', event.target.value)}
+                        required
+                      />
+                    </div>
+
+                    <div className="neuro-surface p-6 rounded-neuro-lg space-y-3">
+                      <label className="block text-sm font-semibold neuro-text-primary">What success looks like</label>
+                      <textarea
+                        className="neuro-input resize-none"
+                        rows={3}
+                        placeholder="How will you know the idea is working?"
+                        value={businessIntakeForm.successDefinition}
+                        onChange={event => handleBusinessIntakeChange('successDefinition', event.target.value)}
+                        required
+                      />
+                    </div>
                   </div>
                 </section>
 


### PR DESCRIPTION
## Summary
- add reusable identifiers for each Assessment & Idea Scope section
- store expanded state for the form sections and expose a toggle helper
- render collapse/expand controls that hide or show each section's fields

## Testing
- npm run lint *(fails: existing repository lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68f6ae4cc13883299de3770410e60b31